### PR TITLE
Update active support usage

### DIFF
--- a/lib/databasedotcom.rb
+++ b/lib/databasedotcom.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/core_ext'
 
 require 'databasedotcom/version'

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -1106,7 +1106,7 @@ describe Databasedotcom::Client do
       it "posts the data to the specified path" do
         stub_request(:post, "https://na1.salesforce.com/my/path").to_return(:body => "", :status => 201)
         @client.http_post("/my/path", "data")
-        WebMock.should have_requested(:post, "https://na1.salesforce.com/my/path").with(:data => "data")
+        WebMock.should have_requested(:post, "https://na1.salesforce.com/my/path").with(:body => "data")
       end
 
       it "puts parameters into the path" do
@@ -1164,7 +1164,7 @@ describe Databasedotcom::Client do
       it "upserts the data to the specified path" do
         stub_request(:patch, "https://na1.salesforce.com/my/path").to_return(:body => "", :status => 201)
         @client.http_patch("/my/path", "data")
-        WebMock.should have_requested(:patch, "https://na1.salesforce.com/my/path").with(:data => "data")
+        WebMock.should have_requested(:patch, "https://na1.salesforce.com/my/path").with(:body => "data")
       end
 
       it "puts parameters into the path" do

--- a/spec/lib/core_extensions/string_extensions_spec.rb
+++ b/spec/lib/core_extensions/string_extensions_spec.rb
@@ -12,8 +12,10 @@ describe "string extensions" do
 
   describe "#constantize" do
     context "when string is empty" do
-      it "returns Object" do
-        "".constantize.should eq(Object)
+      it "raises a NameError" do
+        expect {
+        "".constantize
+        }.to raise_error(NameError)
       end
     end
 


### PR DESCRIPTION
This should close #161.
Starting with ActiveSupport 4.1, ActiveSupport changed the preferred way for cherry picking core extensions (see rails/rails#17936 and https://github.com/rails/rails/blob/4-1-stable/guides/source/active_support_core_extensions.md#cherry-picking-a-definition for more details).

Additionally, a couple other minor housekeeping items were required to make the tests pass.