### PR TITLE
[bugfix] handles case where value is a string

### DIFF
--- a/lib/databasedotcom/client.rb
+++ b/lib/databasedotcom/client.rb
@@ -496,7 +496,7 @@ module Databasedotcom
         attrs.keys.each do |key|
           case clazz.field_type(key.to_s)
             when "multipicklist"
-              coerced_attrs[key] = (attrs[key] || []).join(';')
+              coerced_attrs[key] = ([attrs[key]] || []).join(';')
             when "datetime"
               begin
                 attrs[key] = DateTime.parse(attrs[key]) if attrs[key].is_a?(String)


### PR DESCRIPTION
We are seeing cases there the value coming back in this case was a string (in our case it was 'None') and it was throwing an undefined method `join` error. Might be a problem further up the chain somewhere, but this fixed it.
